### PR TITLE
Dell CSM Operator v1.9.0 - Add airgap support

### DIFF
--- a/packs/dell-csm-operator-1.9.0/values.yaml
+++ b/packs/dell-csm-operator-1.9.0/values.yaml
@@ -1,3 +1,39 @@
+pack:
+  content:
+    images:
+      - image: dellemc/sdc:4.5.1
+      - image: dellemc/csi-metadata-retriever:v1.8.0
+      - image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.124.0
+      - image: quay.io/dell/storage/powerflex/sdc:4.5.2.1
+      - image: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.9.0
+      - image: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.10.0
+      - image: quay.io/dell/container-storage-modules/dell-csm-operator:v1.9.0
+      - image: quay.io/dell/container-storage-modules/csi-isilon:v2.14.0
+      - image: quay.io/dell/container-storage-modules/csi-powermax:v2.14.0
+      - image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:v2.13.0
+      - image: quay.io/dell/container-storage-modules/csi-powerstore:v2.14.0
+      - image: quay.io/dell/container-storage-modules/csi-unity:v2.14.0
+      - image: quay.io/dell/container-storage-modules/csi-vxflexos:v2.14.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.2.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.2.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-tenant:v2.2.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-role:v2.2.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-storage:v2.2.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-controller:v2.2.0
+      - image: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.12.0
+      - image: quay.io/dell/container-storage-modules/dell-replication-controller:v1.12.0
+      - image: quay.io/dell/container-storage-modules/csm-topology:v1.12.0
+      - image: quay.io/dell/container-storage-modules/csm-metrics-powerscale:v1.9.0
+      - image: quay.io/dell/container-storage-modules/csm-metrics-powermax:v1.7.0
+      - image: quay.io/dell/container-storage-modules/csm-metrics-powerflex:v1.12.0
+      - image: quay.io/dell/container-storage-modules/podmon:v1.13.0
+      - image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
+      - image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+      - image: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
+      - image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+      - image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+      - image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.14.0
+
 charts:
   csm-operator:
     namespace: dell-csm-operator

--- a/packs/dell-csm-operator-addon-1.9.0/values.yaml
+++ b/packs/dell-csm-operator-addon-1.9.0/values.yaml
@@ -1,3 +1,39 @@
+pack:
+  content:
+    images:
+      - image: dellemc/sdc:4.5.1
+      - image: dellemc/csi-metadata-retriever:v1.8.0
+      - image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector:0.124.0
+      - image: quay.io/dell/storage/powerflex/sdc:4.5.2.1
+      - image: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.9.0
+      - image: quay.io/dell/container-storage-modules/csi-metadata-retriever:v1.10.0
+      - image: quay.io/dell/container-storage-modules/dell-csm-operator:v1.9.0
+      - image: quay.io/dell/container-storage-modules/csi-isilon:v2.14.0
+      - image: quay.io/dell/container-storage-modules/csi-powermax:v2.14.0
+      - image: quay.io/dell/container-storage-modules/csipowermax-reverseproxy:v2.13.0
+      - image: quay.io/dell/container-storage-modules/csi-powerstore:v2.14.0
+      - image: quay.io/dell/container-storage-modules/csi-unity:v2.14.0
+      - image: quay.io/dell/container-storage-modules/csi-vxflexos:v2.14.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-sidecar:v2.2.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-proxy:v2.2.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-tenant:v2.2.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-role:v2.2.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-storage:v2.2.0
+      - image: quay.io/dell/container-storage-modules/csm-authorization-controller:v2.2.0
+      - image: quay.io/dell/container-storage-modules/dell-csi-replicator:v1.12.0
+      - image: quay.io/dell/container-storage-modules/dell-replication-controller:v1.12.0
+      - image: quay.io/dell/container-storage-modules/csm-topology:v1.12.0
+      - image: quay.io/dell/container-storage-modules/csm-metrics-powerscale:v1.9.0
+      - image: quay.io/dell/container-storage-modules/csm-metrics-powermax:v1.7.0
+      - image: quay.io/dell/container-storage-modules/csm-metrics-powerflex:v1.12.0
+      - image: quay.io/dell/container-storage-modules/podmon:v1.13.0
+      - image: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
+      - image: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+      - image: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
+      - image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+      - image: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+      - image: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.14.0
+
 charts:
   csm-operator:
     namespace: dell-csm-operator


### PR DESCRIPTION
This PR adds `pack.content.images` to the Dell CSM Operator v1.9.0 packs