### PR TITLE
rbac: add resourceclaims/binding permission for DRA granular status authorization

### DIFF
--- a/packs/kai-scheduler-ai-0.10.0/charts/kai-scheduler/templates/rbac/binder.yaml
+++ b/packs/kai-scheduler-ai-0.10.0/charts/kai-scheduler/templates/rbac/binder.yaml
@@ -89,6 +89,7 @@ rules:
   resources:
   - resourceclaims
   - resourceclaims/status
+  - resourceclaims/binding
   verbs:
   - get
   - list


### PR DESCRIPTION
This updates the kai-scheduler binder RBAC in:

packs/kai-scheduler-ai-0.10.0/charts/kai-scheduler/templates/rbac/binder.yaml

to add `resourceclaims/binding` under the existing `resource.k8s.io` rule, which is required for Kubernetes 1.36 DRA granular status authorization.

The role already includes `resourceclaims` and `resourceclaims/status`; this adds the binding subresource permission needed for scheduler/binder updates.