### PR TITLE
chore: replace Bitnami image references with Soldevelo equivalents

### DIFF
--- a/packs/kubevirt-csi-driver-1.0.0/charts/kubevirt-csi-driver/templates/daemonset.yaml
+++ b/packs/kubevirt-csi-driver-1.0.0/charts/kubevirt-csi-driver/templates/daemonset.yaml
@@ -20,7 +20,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:latest
         args:
         - annotate
         - node
@@ -31,7 +31,7 @@ spec:
             cpu: 50m
             memory: 100Mi
       - name: set-node-providerid
-        image: bitnami/kubectl:latest
+        image: soldevelo/kubectl:latest
         env:
         - name: NODENAME
           valueFrom:


### PR DESCRIPTION
## Why this change

Bitnami changed its container image distribution model on August 28, 2025, and public images no longer receive ongoing updates or security fixes.
[SolDevelo](https://hub.docker.com/u/soldevelo) images are free drop-in replacements built from [SolDevelo/containers](https://github.com/SolDevelo/containers), a fork of bitnami/containers that continues to provide actively maintained and publicly available images.

## Image replacements

- `bitnami/kubectl:latest` → [`soldevelo/kubectl:latest`](https://hub.docker.com/r/soldevelo/kubectl)