### PR TITLE
HPE CSI Driver 3.1.0 fixes

### DIFF
--- a/packs/hpe-csi-driver-3.1.0/README.md
+++ b/packs/hpe-csi-driver-3.1.0/README.md
@@ -36,7 +36,7 @@ The only pack parameter that has a different default value from the Helm chart i
 | disableNodeGetVolumeStats | Disable NodeGetVolumeStats call to CSI driver.                                                     | false            |
 | disableNodeMonitor        | Disables the Node Monitor that manages stale storage resources.                                    | false            |
 | disableHostDeletion       | Disables host deletion by the CSP when no volumes are associated with the host.                    | false            |
-| disablePreInstallHooks    | Disable pre-install hooks when the chart is rendered outside of Kubernetes, such as CI/CD systems. | false            |
+| disablePreInstallHooks    | Disable pre-install hooks when the chart is rendered outside of Kubernetes, such as CI/CD systems. | true             |
 | imagePullPolicy           | Image pull policy (`Always`, `IfNotPresent`, `Never`).                                             | IfNotPresent     |
 | iscsi.chapSecretName      | Secret containing chapUser and chapPassword for iSCSI                                              | ""               |
 | logLevel                  | Log level. Can be one of `info`, `debug`, `trace`, `warn` and `error`.                             | info             |

--- a/packs/hpe-csi-driver-3.1.0/values.yaml
+++ b/packs/hpe-csi-driver-3.1.0/values.yaml
@@ -3,7 +3,6 @@ pack:
   content:
     images:
       - image: quay.io/hpestorage/csi-driver:v3.1.0
-      - image: quay.io/hpestorage/csi-driver:v3.1.0
       - image: quay.io/hpestorage/alletra-6000-and-nimble-csp:v3.1.0
       - image: quay.io/hpestorage/alletra-9000-primera-and-3par-csp:v3.1.0
       - image: quay.io/hpestorage/alletrastoragemp-b10000-nfs-csp:v1.1.0
@@ -52,7 +51,7 @@ charts:
     disableHostDeletion: false
 
     # Disable pre-install hooks when the chart is rendered outside of Kubernetes, such as CI/CD systems
-    disablePreInstallHooks: false
+    disablePreInstallHooks: true
 
     # imagePullPolicy applied for all hpe-csi-driver images
     imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
- Duplicate image in image list
- Disabled pre-install hook due to install issue