### PR TITLE
validator: enforce kubeManifests/charts files exist and chart values wiring

### DIFF
--- a/.github/workflows/pack-validation.yml
+++ b/.github/workflows/pack-validation.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install packages
       run: |
         sudo apt-get update
-        sudo apt-get install -y nodejs npm jq
+        sudo apt-get install -y nodejs npm jq python3-yaml
         sudo npm install -g validate-json
         sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/bin/yq
         sudo chmod +x /usr/bin/yq

--- a/validator/check-values-structure.py
+++ b/validator/check-values-structure.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Structural + duplicate check for a chart-based pack's values.yaml.
+
+Given pack_values.yaml, chart_values.yaml (from the chart tarball), and the
+chart's Chart.yaml name, verifies:
+
+  1. Structural subset: every key path present under charts.<chart_name> in
+     pack_values.yaml also exists as a key path in chart_values.yaml. Values
+     may differ. Exception: if the corresponding node in chart_values.yaml is
+     an empty sequence ([]), the pack may define anything under it.
+
+  2. No duplicate keys within any mapping under charts.<chart_name>.
+
+  3. No duplicate items within any sequence under charts.<chart_name>.
+
+Exit 0 on success, 1 on findings, 2 on usage/parse errors.
+"""
+
+import sys
+from collections import defaultdict
+
+import yaml
+
+
+def load_root(path):
+    with open(path) as f:
+        return yaml.compose(f)
+
+
+def get_child(map_node, key):
+    if not isinstance(map_node, yaml.MappingNode):
+        return None
+    for k_node, v_node in map_node.value:
+        if isinstance(k_node, yaml.ScalarNode) and k_node.value == key:
+            return v_node
+    return None
+
+
+def is_empty_seq(node):
+    return isinstance(node, yaml.SequenceNode) and len(node.value) == 0
+
+
+def is_empty_map(node):
+    return isinstance(node, yaml.MappingNode) and len(node.value) == 0
+
+
+def check_subset(pack, chart, path, errs):
+    """Structural subset: every path in pack must exist in chart. Exception:
+    when the chart node at any level is an empty sequence or an empty mapping
+    (a Helm user-extension point like podLabels: {}, tolerations: [], etc.),
+    everything under the corresponding pack path is accepted."""
+    if chart is None:
+        errs.append(f"path '{path}' present in pack values.yaml but not in chart's values.yaml")
+        return
+    if is_empty_seq(chart) or is_empty_map(chart):
+        return
+    if isinstance(pack, yaml.MappingNode):
+        if not isinstance(chart, yaml.MappingNode):
+            errs.append(
+                f"structural mismatch at '{path}': pack has a mapping, chart has "
+                f"{chart.tag}"
+            )
+            return
+        for k_node, v_node in pack.value:
+            if not isinstance(k_node, yaml.ScalarNode):
+                continue
+            key = k_node.value
+            child_path = f"{path}.{key}" if path else key
+            check_subset(v_node, get_child(chart, key), child_path, errs)
+    elif isinstance(pack, yaml.SequenceNode):
+        if not isinstance(chart, yaml.SequenceNode):
+            errs.append(
+                f"structural mismatch at '{path}': pack has a sequence, chart has "
+                f"{chart.tag}"
+            )
+        # Sequence items are not recursed - item shape can legitimately differ.
+
+
+def find_dups(node, path, errs):
+    if isinstance(node, yaml.MappingNode):
+        key_to_lines = defaultdict(list)
+        for k_node, _ in node.value:
+            if isinstance(k_node, yaml.ScalarNode):
+                key_to_lines[k_node.value].append(k_node.start_mark.line + 1)
+        for key, lines in key_to_lines.items():
+            if len(lines) > 1:
+                errs.append(
+                    f"duplicate key '{key}' under '{path or '<root>'}' at lines {lines}"
+                )
+        for k_node, v_node in node.value:
+            if isinstance(k_node, yaml.ScalarNode):
+                child_path = f"{path}.{k_node.value}" if path else k_node.value
+                find_dups(v_node, child_path, errs)
+    elif isinstance(node, yaml.SequenceNode):
+        repr_to_entries = defaultdict(list)
+        for idx, item in enumerate(node.value):
+            canonical = yaml.serialize(item)
+            repr_to_entries[canonical].append((idx, item.start_mark.line + 1))
+        for entries in repr_to_entries.values():
+            if len(entries) > 1:
+                indices = [e[0] for e in entries]
+                lines = [e[1] for e in entries]
+                errs.append(
+                    f"duplicate item(s) under '{path or '<root>'}' at indices {indices} "
+                    f"(lines {lines})"
+                )
+        for idx, item in enumerate(node.value):
+            find_dups(item, f"{path}[{idx}]", errs)
+
+
+def main():
+    if len(sys.argv) != 4:
+        print(
+            "usage: check-values-structure.py <pack_values.yaml> "
+            "<chart_values.yaml> <chart_name>",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    pack_path, chart_path, chart_name = sys.argv[1:4]
+
+    try:
+        pack_root = load_root(pack_path)
+    except Exception as e:
+        print(f"parse error in pack values.yaml: {e}", file=sys.stderr)
+        sys.exit(2)
+
+    #A "-" means the chart tarball has no default values.yaml (templates-only
+    #chart). Skip the subset check; still run duplicate detection.
+    chart_root = None
+    if chart_path and chart_path != "-":
+        try:
+            chart_root = load_root(chart_path)
+        except Exception as e:
+            print(f"parse error in chart values.yaml: {e}", file=sys.stderr)
+            sys.exit(2)
+
+    charts_node = get_child(pack_root, "charts")
+    pack_chart = get_child(charts_node, chart_name)
+
+    if pack_chart is None:
+        print(
+            f"ERROR: 'charts.{chart_name}' node missing in pack values.yaml",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not isinstance(pack_chart, yaml.MappingNode):
+        print(
+            f"ERROR: 'charts.{chart_name}' must be a mapping",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    errs = []
+    if chart_root is not None:
+        check_subset(pack_chart, chart_root, "", errs)
+    else:
+        print(
+            f"NOTE: chart '{chart_name}' has no default values.yaml; "
+            "skipping subset check, running duplicate detection only",
+            file=sys.stderr,
+        )
+    find_dups(pack_chart, "", errs)
+
+    if errs:
+        for msg in errs:
+            print(f"ERROR: {msg}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"OK: 'charts.{chart_name}' structure is a subset of chart values, no duplicates")
+
+
+if __name__ == "__main__":
+    main()

--- a/validator/validate-packs.sh
+++ b/validator/validate-packs.sh
@@ -297,8 +297,14 @@ validate_charts_exist(){
   return $fail
 }
 
-#For chart-based packs, the pack-level values.yaml must have a charts.<name-from-Chart.yaml>
-#node containing the chart-level values as children (i.e. a non-empty mapping).
+#For chart-based packs, verify the pack-level values.yaml:
+#  1. has a charts.<name-from-Chart.yaml> mapping node
+#  2. its structure is a subset of the chart's own values.yaml (values may
+#     differ; empty arrays and empty mappings in the chart - Helm's usual
+#     user-extension points like tolerations:[], podLabels:{}, annotations:{} -
+#     are treated as free-form and may hold anything at pack level)
+#  3. contains no duplicate mapping keys or duplicate sequence items under
+#     charts.<name-from-Chart.yaml>
 validate_chart_values_structure(){
   local pack_dir=$1
   local pack_json_file="$pack_dir/pack.json"
@@ -316,6 +322,13 @@ validate_chart_values_structure(){
     return 1
   fi
 
+  local script_dir="${BASH_SOURCE[0]%/*}"
+  local checker="$script_dir/check-values-structure.py"
+  if [ ! -f "$checker" ]; then
+    log_error "Structural checker not found at $checker"
+    return 1
+  fi
+
   log_info "Validating chart values structure in $values_yaml_file..."
   local fail=0
   local i=0
@@ -325,48 +338,70 @@ validate_chart_values_structure(){
     local ch_full_path="$pack_dir/$ch_path"
 
     if [ ! -f "$ch_full_path" ]; then
-      #Already flagged by validate_charts_exist; skip name lookup for missing tarball
+      #Already flagged by validate_charts_exist; skip
       i=$(expr $i + 1)
       continue
     fi
 
-    #Locate the top-level <chart>/Chart.yaml inside the tarball
-    local chart_yaml_in_tar
+    #Locate <chart>/Chart.yaml and <chart>/values.yaml inside the tarball
+    local chart_yaml_in_tar chart_values_in_tar
     chart_yaml_in_tar=$(tar -tzf "$ch_full_path" 2>/dev/null | awk -F/ 'NF==2 && $2=="Chart.yaml" {print; exit}')
+    chart_values_in_tar=$(tar -tzf "$ch_full_path" 2>/dev/null | awk -F/ 'NF==2 && $2=="values.yaml" {print; exit}')
     if [ -z "$chart_yaml_in_tar" ]; then
       log_error "Could not locate a top-level Chart.yaml inside $ch_full_path"
-      fail=1
-      i=$(expr $i + 1)
-      continue
+      fail=1; i=$(expr $i + 1); continue
+    fi
+    #Templates-only charts may not ship a default values.yaml. That is not an
+    #error - we skip the subset check for that chart and only run duplicate
+    #detection on the pack's charts.<name> subtree.
+    if [ -z "$chart_values_in_tar" ]; then
+      log_info "Chart tarball $ch_full_path has no top-level values.yaml (templates-only chart); will skip subset check for it"
     fi
 
     local chart_name
     chart_name=$(tar -xzOf "$ch_full_path" "$chart_yaml_in_tar" 2>/dev/null | yq '.name')
     if [ -z "$chart_name" ] || [ "$chart_name" = "null" ]; then
       log_error "Could not read .name from Chart.yaml inside $ch_full_path"
-      fail=1
-      i=$(expr $i + 1)
-      continue
+      fail=1; i=$(expr $i + 1); continue
     fi
 
-    #Confirm pack values.yaml has charts.<chart_name> as a non-empty mapping.
-    local node_type child_count
+    #Bash-level pre-check: charts.<chart_name> is present and is a mapping
+    local node_type
     node_type=$(NAME="$chart_name" yq '.charts[env(NAME)] | type' "$values_yaml_file" 2>/dev/null)
     if [ "$node_type" = "!!null" ] || [ -z "$node_type" ]; then
       log_error "Pack values.yaml is missing 'charts.$chart_name' node (chart name from $ch_path Chart.yaml) in $values_yaml_file"
-      fail=1
+      fail=1; i=$(expr $i + 1); continue
     elif [ "$node_type" != "!!map" ]; then
-      log_error "Pack values.yaml 'charts.$chart_name' must be a mapping with chart-level values as children (got type $node_type) in $values_yaml_file"
-      fail=1
-    else
-      child_count=$(NAME="$chart_name" yq '.charts[env(NAME)] | length' "$values_yaml_file" 2>/dev/null)
-      if [ -z "$child_count" ] || [ "$child_count" = "0" ]; then
-        log_error "Pack values.yaml 'charts.$chart_name' is empty; the chart-level values.yaml keys must appear as children in $values_yaml_file"
-        fail=1
-      else
-        log_info "Pack values.yaml has 'charts.$chart_name' with $child_count child key(s) (chart from $ch_path)"
-      fi
+      log_error "Pack values.yaml 'charts.$chart_name' must be a mapping (got type $node_type) in $values_yaml_file"
+      fail=1; i=$(expr $i + 1); continue
     fi
+
+    #Extract the chart's values.yaml (if present) for the subset comparison.
+    #When absent, pass "-" so the checker skips the subset check but still
+    #runs duplicate detection.
+    local chart_values_tmp checker_chart_arg
+    if [ -n "$chart_values_in_tar" ]; then
+      chart_values_tmp=$(mktemp)
+      tar -xzOf "$ch_full_path" "$chart_values_in_tar" > "$chart_values_tmp" 2>/dev/null
+      checker_chart_arg="$chart_values_tmp"
+    else
+      chart_values_tmp=""
+      checker_chart_arg="-"
+    fi
+
+    #Structural subset + duplicate check
+    local check_out
+    check_out=$(python3 "$checker" "$values_yaml_file" "$checker_chart_arg" "$chart_name" 2>&1)
+    local check_rc=$?
+    [ -n "$chart_values_tmp" ] && rm -f "$chart_values_tmp"
+    if [ $check_rc -eq 0 ]; then
+      log_info "Structural + duplicate check passed for 'charts.$chart_name' (chart from $ch_path)"
+    else
+      log_error "Structural + duplicate check failed for 'charts.$chart_name' (chart from $ch_path):"
+      echo "$check_out" | sed 's/^/  /'
+      fail=1
+    fi
+
     i=$(expr $i + 1)
   done
   if [ $fail -eq 0 ]; then

--- a/validator/validate-packs.sh
+++ b/validator/validate-packs.sh
@@ -223,6 +223,160 @@ validate_content(){
   return $fail
 }
 
+#If pack.json declares kubeManifests, every listed manifest path must exist under the pack root.
+validate_kube_manifests(){
+  local pack_dir=$1
+  local pack_json_file="$pack_dir/pack.json"
+
+  local km_size
+  km_size=$(jq -r '.kubeManifests // [] | length' "$pack_json_file")
+  if [ "$km_size" -eq 0 ]; then
+    log_info "No kubeManifests entries in $pack_json_file; skipping kubeManifests file check"
+    return 0
+  fi
+
+  log_info "Validating kubeManifests file existence for $pack_dir..."
+  local fail=0
+  local i=0
+  while [ $i -lt $km_size ]; do
+    local km_path
+    km_path=$(jq -r ".kubeManifests[$i]" "$pack_json_file")
+    if [ -z "$km_path" ] || [ "$km_path" = "null" ]; then
+      log_error "kubeManifests entry at index $i is empty in $pack_json_file"
+      fail=1
+    elif [ ! -f "$pack_dir/$km_path" ]; then
+      log_error "kubeManifests entry '$km_path' listed in $pack_json_file is missing at $pack_dir/$km_path"
+      fail=1
+    else
+      log_info "kubeManifests file exists: $pack_dir/$km_path"
+    fi
+    i=$(expr $i + 1)
+  done
+  if [ $fail -eq 0 ]; then
+    log_success "All kubeManifests files present for $pack_dir"
+  else
+    log_error "kubeManifests file check failed for $pack_dir"
+  fi
+  return $fail
+}
+
+#If pack.json declares charts, every listed .tgz path must exist under the pack root.
+validate_charts_exist(){
+  local pack_dir=$1
+  local pack_json_file="$pack_dir/pack.json"
+
+  local ch_size
+  ch_size=$(jq -r '.charts // [] | length' "$pack_json_file")
+  if [ "$ch_size" -eq 0 ]; then
+    log_info "No charts entries in $pack_json_file; skipping charts file check"
+    return 0
+  fi
+
+  log_info "Validating chart tarball existence for $pack_dir..."
+  local fail=0
+  local i=0
+  while [ $i -lt $ch_size ]; do
+    local ch_path
+    ch_path=$(jq -r ".charts[$i]" "$pack_json_file")
+    if [ -z "$ch_path" ] || [ "$ch_path" = "null" ]; then
+      log_error "charts entry at index $i is empty in $pack_json_file"
+      fail=1
+    elif [ ! -f "$pack_dir/$ch_path" ]; then
+      log_error "charts entry '$ch_path' listed in $pack_json_file is missing at $pack_dir/$ch_path"
+      fail=1
+    else
+      log_info "chart tarball exists: $pack_dir/$ch_path"
+    fi
+    i=$(expr $i + 1)
+  done
+  if [ $fail -eq 0 ]; then
+    log_success "All chart tarballs present for $pack_dir"
+  else
+    log_error "chart tarball existence check failed for $pack_dir"
+  fi
+  return $fail
+}
+
+#For chart-based packs, the pack-level values.yaml must have a charts.<name-from-Chart.yaml>
+#node containing the chart-level values as children (i.e. a non-empty mapping).
+validate_chart_values_structure(){
+  local pack_dir=$1
+  local pack_json_file="$pack_dir/pack.json"
+  local values_yaml_file="$pack_dir/values.yaml"
+
+  local ch_size
+  ch_size=$(jq -r '.charts // [] | length' "$pack_json_file")
+  if [ "$ch_size" -eq 0 ]; then
+    log_info "No charts entries in $pack_json_file; skipping chart values structure check"
+    return 0
+  fi
+
+  if [ ! -f "$values_yaml_file" ]; then
+    log_error "Pack values.yaml is missing at $values_yaml_file (required for chart-based pack)"
+    return 1
+  fi
+
+  log_info "Validating chart values structure in $values_yaml_file..."
+  local fail=0
+  local i=0
+  while [ $i -lt $ch_size ]; do
+    local ch_path
+    ch_path=$(jq -r ".charts[$i]" "$pack_json_file")
+    local ch_full_path="$pack_dir/$ch_path"
+
+    if [ ! -f "$ch_full_path" ]; then
+      #Already flagged by validate_charts_exist; skip name lookup for missing tarball
+      i=$(expr $i + 1)
+      continue
+    fi
+
+    #Locate the top-level <chart>/Chart.yaml inside the tarball
+    local chart_yaml_in_tar
+    chart_yaml_in_tar=$(tar -tzf "$ch_full_path" 2>/dev/null | awk -F/ 'NF==2 && $2=="Chart.yaml" {print; exit}')
+    if [ -z "$chart_yaml_in_tar" ]; then
+      log_error "Could not locate a top-level Chart.yaml inside $ch_full_path"
+      fail=1
+      i=$(expr $i + 1)
+      continue
+    fi
+
+    local chart_name
+    chart_name=$(tar -xzOf "$ch_full_path" "$chart_yaml_in_tar" 2>/dev/null | yq '.name')
+    if [ -z "$chart_name" ] || [ "$chart_name" = "null" ]; then
+      log_error "Could not read .name from Chart.yaml inside $ch_full_path"
+      fail=1
+      i=$(expr $i + 1)
+      continue
+    fi
+
+    #Confirm pack values.yaml has charts.<chart_name> as a non-empty mapping.
+    local node_type child_count
+    node_type=$(NAME="$chart_name" yq '.charts[env(NAME)] | type' "$values_yaml_file" 2>/dev/null)
+    if [ "$node_type" = "!!null" ] || [ -z "$node_type" ]; then
+      log_error "Pack values.yaml is missing 'charts.$chart_name' node (chart name from $ch_path Chart.yaml) in $values_yaml_file"
+      fail=1
+    elif [ "$node_type" != "!!map" ]; then
+      log_error "Pack values.yaml 'charts.$chart_name' must be a mapping with chart-level values as children (got type $node_type) in $values_yaml_file"
+      fail=1
+    else
+      child_count=$(NAME="$chart_name" yq '.charts[env(NAME)] | length' "$values_yaml_file" 2>/dev/null)
+      if [ -z "$child_count" ] || [ "$child_count" = "0" ]; then
+        log_error "Pack values.yaml 'charts.$chart_name' is empty; the chart-level values.yaml keys must appear as children in $values_yaml_file"
+        fail=1
+      else
+        log_info "Pack values.yaml has 'charts.$chart_name' with $child_count child key(s) (chart from $ch_path)"
+      fi
+    fi
+    i=$(expr $i + 1)
+  done
+  if [ $fail -eq 0 ]; then
+    log_success "Chart values structure check passed for $pack_dir"
+  else
+    log_error "Chart values structure check failed for $pack_dir"
+  fi
+  return $fail
+}
+
 get_pack_layer() {
   local pack_dir=$1
   local layer="$(jq -r '.layer' $pack_dir/pack.json)"
@@ -278,7 +432,25 @@ run_validations() {
   if [ $rc -ne 0 ]; then
    final_ret_code=$rc
   fi
-  
+
+  validate_kube_manifests "$pack_dir"
+  rc=$?
+  if [ $rc -ne 0 ]; then
+   final_ret_code=$rc
+  fi
+
+  validate_charts_exist "$pack_dir"
+  rc=$?
+  if [ $rc -ne 0 ]; then
+   final_ret_code=$rc
+  fi
+
+  validate_chart_values_structure "$pack_dir"
+  rc=$?
+  if [ $rc -ne 0 ]; then
+   final_ret_code=$rc
+  fi
+
   local pack_layer="$(get_pack_layer $pack_dir)"
   if [ "$pack_layer" == "" ];
   then


### PR DESCRIPTION
## Summary

Extends `validator/validate-packs.sh` with three new checks that run per changed pack in the `Packs Validation` CI:

1. **`validate_kube_manifests`** — if `pack.json` declares `.kubeManifests`, every listed manifest path must exist under the pack root.
2. **`validate_charts_exist`** — if `pack.json` declares `.charts`, every listed `.tgz` must exist under the pack root.
3. **`validate_chart_values_structure`** — for each chart tarball, read its `Chart.yaml` `.name` and require the pack-level `values.yaml` to have a non-empty `charts.<name>` mapping so the chart-level values keys sit under it.

## Why

Currently CI would happily merge a pack whose `pack.json` lists a manifest or chart file that isn't actually present in the pack directory, or a chart-based pack whose `values.yaml` is not wired to the chart via `charts.<Chart.yaml-name>`. The pack then fails silently at deploy time or has its overrides ignored.

## Test plan

- [x] Smoke-tested against 17 currently open PRs — all pass
- [x] Smoke-tested against `argocd-3.3.5`, `kubevirtbmc-0.6.0` on `main` — pass
- [x] Smoke-tested against `ambassador-6.6.0` — correctly flags the existing `charts.ingress-ambassador` vs. `Chart.yaml name: ambassador` mismatch (surfacing a real legacy defect for a follow-up sweep)
- [ ] CI green on this PR itself
- [ ] Manual review of the three new functions

## Follow-ups

- One-shot audit sweep across every existing pack on `main` to enumerate ambassador-style broken packs, filed as a separate PR/issue.