### PR TITLE
gitleaksignore: allowlist Percona MongoDB placeholders in nvidia-nvsentinel-v1.19.0

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -65,3 +65,5 @@ a1b4bf1043a7f3681fdd294579be16aa76a03549:packs/kubewatch-1.0.7/values.yaml:gener
 6dcc3f04f80fe8429a878a572bfc59ea94d09f93:packs/sriov-network-operator-1.6.0/charts/sriov-network-operator-chart/values.yaml:private-key:87
 6dcc3f04f80fe8429a878a572bfc59ea94d09f93:packs/sriov-network-operator-1.6.0/values.yaml:private-key:93
 6dcc3f04f80fe8429a878a572bfc59ea94d09f93:packs/sriov-network-operator-1.6.0/values.yaml:private-key:109
+c9f6f8d1c46e6bcbde37938b891053075174f1bc:packs/nvidia-nvsentinel-v1.19.0/charts/nvsentinel/charts/mongodb-store/charts/psmdb-db/values.yaml:generic-api-key:675
+c9f6f8d1c46e6bcbde37938b891053075174f1bc:packs/nvidia-nvsentinel-v1.19.0/charts/nvsentinel/charts/mongodb-store/charts/psmdb-db/values.yaml:generic-api-key:678


### PR DESCRIPTION
## Summary

Adds two fingerprints to `.gitleaksignore` for the bundled Percona MongoDB (psmdb-db) chart's `values.yaml` in `packs/nvidia-nvsentinel-v1.19.0/`. Both are commented-out AWS S3/KMS backup config placeholders shipped by Percona upstream:

```
line 675: kmsKeyID: 1234abcd-12ab-34cd-56ef-1234567890ab
line 678: sseCustomerKey: Y3VzdG9tZXIta2V5   (base64 for "customer-key")
```

They are inert documentation examples inside upstream chart defaults and get flagged by the `generic-api-key` rule — false positives.

Unblocks the [BulwarkGitLeaks check on #303](https://github.com/spectrocloud/pack-central/actions/runs/32707510131/job/97371651297?pr=303).

## Test plan

- [ ] BulwarkGitLeaks passes on this PR (it does not add the leaked file itself, so should be a no-op scan)
- [ ] After merge, PR #303 re-runs BulwarkGitLeaks and passes with these fingerprints matched